### PR TITLE
Enforce arrow function parens

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
     "no-console": 2,
     "semi": [2, "always"],
     "comma-dangle": [2, "only-multiline"],
-    "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
+    "arrow-parens": [2, "always", { "requireForBlockBody": true }],
     "filenames/match-regex": [2, "^[a-z0-9\\-\\.]+$"],
 
     // warnings


### PR DESCRIPTION
Treat arrow functions like they're going to a rated-R movie - they need to bring their parens with them.

There are a couple reason I'm pushing for this:

1. Adding and removing arguments doesn't affect parens

```js
() => stuff
(one) => stuff
(one, two) => stuff
```

2. Consistency. It's less confusing if it always looks the same.