### PR TITLE
Allow named functions to be passed as callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports = {
     "comma-dangle": [2, "only-multiline"],
     "arrow-parens": [2, "as-needed", { "requireForBlockBody": true }],
     "filenames/match-regex": [2, "^[a-z0-9\\-\\.]+$"],
+    "prefer-arrow-callback": [2, { "allowNamedFunctions": true }],
 
     // warnings
     "indent": [1, 2, { "SwitchCase": 1 }],


### PR DESCRIPTION
This allows us to pass in functional components as callbacks to HOCs
without linter complaining.