### PR TITLE
Update ESLint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.16.1",
+    "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
3.16.1 does not respect some of the configurations we're using from
AirBnB.