### PR TITLE
Add shared-node-browser and jest to env

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ module.exports = {
   "extends": "airbnb",
   "env": {
     "amd": true,
-    "browser": true,
     "es6": true,
+    "shared-node-browser": true,
+    "jest": true
   },
   "parser": "babel-eslint",
   "plugins": [


### PR DESCRIPTION
- removes browser from env. variables such as document and any globals attached to window will now be flagged as undefined

- shared-node-browser marks globals such as `setTimeout/Interval`, `clearTimeout/Interval` and and `console` as defined

- jest marks globals such as `describe`, the before hooks, and `test` as defined