### PR TITLE
Require trailing commas for multiline objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
     // errors
     "no-console": 2,
     "semi": [2, "always"],
-    "comma-dangle": [2, "only-multiline"],
+    "comma-dangle": [2, "always-multiline"],
     "arrow-parens": [2, "always", { "requireForBlockBody": true }],
     "filenames/match-regex": [2, "^[a-z0-9\\-\\.]+$"],
     "prefer-arrow-callback": [2, { "allowNamedFunctions": true }],


### PR DESCRIPTION
Trailing commas allow for cleaner diffs when adding a single line. This
rule also applys to arrays, imports and exports.

```js
const example = {
  hello: 'world',
};
```